### PR TITLE
final beta7

### DIFF
--- a/api/serializers/payment_serializer.py
+++ b/api/serializers/payment_serializer.py
@@ -673,18 +673,18 @@ def generate_periods_and_payments(employer, generate_since=None):
                     regular_hours = projected_hours
                     overtime = clocked_hours - projected_hours
 
-                payment = PayrollPeriodPayment(
-                    payroll_period=period,
-                    employee=clockin.employee,
-                    employer=employer,
-                    shift=clockin.shift,
-                    clockin=clockin,
-                    regular_hours=regular_hours,
-                    over_time=overtime,
-                    hourly_rate=clockin.shift.minimum_hourly_rate,
-                    total_amount=round((regular_hours + overtime) * clockin.shift.minimum_hourly_rate, 2),
-                    splited_payment=False if clockin.ended_at is None or (clockin.started_at == starting_time and ending_time == clockin.ended_at) else True
-                )
+                payment = PayrollPeriodPayment()
+                payment.payroll_period=period,
+                payment.employee=clockin.employee,
+                payment.employer=employer,
+                payment.shift=clockin.shift,
+                payment.clockin=clockin,
+                payment.regular_hours=regular_hours,
+                payment.over_time=overtime,
+                payment.hourly_rate=clockin.shift.minimum_hourly_rate,
+                payment.total_amount=round((regular_hours + overtime) * clockin.shift.minimum_hourly_rate, 2),
+                payment.splited_payment=False if clockin.ended_at is None or (clockin.started_at == starting_time and ending_time == clockin.ended_at) else True
+                
                 payment.save()
                 total_payments = total_payments + 1
 

--- a/api/tests/test_employee_payment.py
+++ b/api/tests/test_employee_payment.py
@@ -124,8 +124,8 @@ class EmployeePaymentTestSuite(TestCase, WithMakeUser, WithMakePayrollPeriod, Wi
         self.assertIsInstance(payment.get('deduction_list'), list, payment)
         self.assertGreaterEqual(len(payment.get('deduction_list')), 2, payment)
         self.assertEqual(Decimal(payment.get('earnings')),
-                              (Decimal(payment.get('amount')) + Decimal(payment.get('taxes'))
-                               + Decimal(payment.get('deductions')), 2),
+                         round(Decimal(payment.get('amount')) + Decimal(payment.get('taxes'))
+                               + Decimal(payment.get('deductions'))),
                          payment)
         self.assertIsInstance(payment.get('employee'), dict, payment)
         self.assertIsInstance(payment.get('employee').get('bank_accounts'), list, payment)


### PR DESCRIPTION
PayrollPeriodPayment() reform payment_serializer:676
api/tests/test_employee_payment.py not 2 decimals but 0 as default round()